### PR TITLE
Add assertions for commands that use type

### DIFF
--- a/src/main/java/dodo/command/AddCommand.java
+++ b/src/main/java/dodo/command/AddCommand.java
@@ -49,6 +49,7 @@ public class AddCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, UI ui, Storage storage) {
+        assert (0 <= type && type >= 2);
         try {
             DodoCheck.addCommandCheck(contents);
         } catch (DodoException ex) {

--- a/src/main/java/dodo/command/InvalidCommand.java
+++ b/src/main/java/dodo/command/InvalidCommand.java
@@ -32,6 +32,7 @@ public class InvalidCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, UI ui, Storage storage) {
+        assert(type == 0 || type == 1);
         switch(type) {
         case 0: // No command line
             return ui.getEmptyCommandMessage();

--- a/src/main/java/dodo/command/MarkCommand.java
+++ b/src/main/java/dodo/command/MarkCommand.java
@@ -38,6 +38,7 @@ public class MarkCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, UI ui, Storage storage) {
+        assert (type == 0 || type == 1);
         if (type == 0) { // mark
             int targetNo;
             try {


### PR DESCRIPTION
Add, invalid and mark commands use an integer type for certain functions.

These integers have a set range of values. Falling outside of these ranges will cause issues.

Let's add assertions to check ensure they always fall within their values.

These variables are not influenced directly by the user, so any invalid input is indicative of a program bug, not user error.

So, using an assertion to handle it seems appropriate, as opposed to using it to check something like command typos, where we want the user to be able to correct their command instead of closing down the program.